### PR TITLE
fix compilation on non-Windows systems (Ubuntu/GCC 7.4)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,46 +9,56 @@ find_package(FFmpeg REQUIRED COMPONENTS avcodec avutil)
 include_directories(${FFMPEG_INCLUDE_DIRS})
 
 set(replay-source_HEADERS
-	replay.h
-	../win-dshow/ffmpeg-decode.h)
+	replay.h)
 set(replay-source_SOURCES
 	replay.c
 	replay-source.c
 	replay-filter.c
 	replay-filter-audio.c
-	replay-filter-async.c
-	win-dshow-replay.cpp
-	../win-dshow/ffmpeg-decode.c)
+	replay-filter-async.c)
 
-set(libdshowcapture_SOURCES
-	../win-dshow/libdshowcapture/source/capture-filter.cpp
-	../win-dshow/libdshowcapture/source/output-filter.cpp
-	../win-dshow/libdshowcapture/source/dshowcapture.cpp
-	../win-dshow/libdshowcapture/source/dshowencode.cpp
-	../win-dshow/libdshowcapture/source/device.cpp
-	../win-dshow/libdshowcapture/source/encoder.cpp
-	../win-dshow/libdshowcapture/source/dshow-base.cpp
-	../win-dshow/libdshowcapture/source/dshow-demux.cpp
-	../win-dshow/libdshowcapture/source/dshow-enum.cpp
-	../win-dshow/libdshowcapture/source/dshow-formats.cpp
-	../win-dshow/libdshowcapture/source/dshow-media-type.cpp
-	../win-dshow/libdshowcapture/source/dshow-encoded-device.cpp
-	../win-dshow/libdshowcapture/source/log.cpp)
+if(WIN32)
+	list(APPEND replay-source_HEADERS
+		../win-dshow/ffmpeg-decode.h)
+	list(APPEND replay-source_SOURCES
+		win-dshow-replay.cpp
+		../win-dshow/ffmpeg-decode.c)
 
-set(libdshowcapture_HEADERS
-	../win-dshow/libdshowcapture/dshowcapture.hpp
-	../win-dshow/libdshowcapture/source/IVideoCaptureFilter.h
-	../win-dshow/libdshowcapture/source/capture-filter.hpp
-	../win-dshow/libdshowcapture/source/output-filter.hpp
-	../win-dshow/libdshowcapture/source/device.hpp
-	../win-dshow/libdshowcapture/source/encoder.hpp
-	../win-dshow/libdshowcapture/source/dshow-base.hpp
-	../win-dshow/libdshowcapture/source/dshow-demux.hpp
-	../win-dshow/libdshowcapture/source/dshow-device-defs.hpp
-	../win-dshow/libdshowcapture/source/dshow-enum.hpp
-	../win-dshow/libdshowcapture/source/dshow-formats.hpp
-	../win-dshow/libdshowcapture/source/dshow-media-type.hpp
-	../win-dshow/libdshowcapture/source/log.hpp)
+	list(APPEND replay-source_PLATFORM_DEPS
+		strmiids
+		ksuser
+		wmcodecdspuuid)
+
+	set(libdshowcapture_SOURCES
+		../win-dshow/libdshowcapture/source/capture-filter.cpp
+		../win-dshow/libdshowcapture/source/output-filter.cpp
+		../win-dshow/libdshowcapture/source/dshowcapture.cpp
+		../win-dshow/libdshowcapture/source/dshowencode.cpp
+		../win-dshow/libdshowcapture/source/device.cpp
+		../win-dshow/libdshowcapture/source/encoder.cpp
+		../win-dshow/libdshowcapture/source/dshow-base.cpp
+		../win-dshow/libdshowcapture/source/dshow-demux.cpp
+		../win-dshow/libdshowcapture/source/dshow-enum.cpp
+		../win-dshow/libdshowcapture/source/dshow-formats.cpp
+		../win-dshow/libdshowcapture/source/dshow-media-type.cpp
+		../win-dshow/libdshowcapture/source/dshow-encoded-device.cpp
+		../win-dshow/libdshowcapture/source/log.cpp)
+
+	set(libdshowcapture_HEADERS
+		../win-dshow/libdshowcapture/dshowcapture.hpp
+		../win-dshow/libdshowcapture/source/IVideoCaptureFilter.h
+		../win-dshow/libdshowcapture/source/capture-filter.hpp
+		../win-dshow/libdshowcapture/source/output-filter.hpp
+		../win-dshow/libdshowcapture/source/device.hpp
+		../win-dshow/libdshowcapture/source/encoder.hpp
+		../win-dshow/libdshowcapture/source/dshow-base.hpp
+		../win-dshow/libdshowcapture/source/dshow-demux.hpp
+		../win-dshow/libdshowcapture/source/dshow-device-defs.hpp
+		../win-dshow/libdshowcapture/source/dshow-enum.hpp
+		../win-dshow/libdshowcapture/source/dshow-formats.hpp
+		../win-dshow/libdshowcapture/source/dshow-media-type.hpp
+		../win-dshow/libdshowcapture/source/log.hpp)
+endif()
 
 add_library(replay-source MODULE
 	${replay-source_HEADERS}
@@ -58,9 +68,6 @@ add_library(replay-source MODULE
 target_link_libraries(replay-source
 	obs-frontend-api
 	libobs
-	strmiids
-	ksuser
-	wmcodecdspuuid
 	${FFMPEG_LIBRARIES}
 	${replay-source_PLATFORM_DEPS})
 

--- a/replay-filter-audio.c
+++ b/replay-filter-audio.c
@@ -68,7 +68,7 @@ static void replay_filter_remove(void *data, obs_source_t *parent)
 	free_audio_data(filter);
 }
 
-obs_properties_t *replay_filter_properties(void *unused)
+static obs_properties_t *replay_filter_properties(void *unused)
 {
 	UNUSED_PARAMETER(unused);
 

--- a/replay-source.c
+++ b/replay-source.c
@@ -595,7 +595,7 @@ static void replay_purge_replays(struct replay_source *context)
 		pthread_mutex_unlock(&context->replay_mutex);
 	}
 }
-void replay_retrieve(struct replay_source *c);
+static void replay_retrieve(struct replay_source *c);
 
 void replay_trigger_threshold(void *data)
 {

--- a/replay.c
+++ b/replay.c
@@ -105,7 +105,9 @@ extern struct obs_source_info replay_filter_audio_info;
 extern struct obs_source_info replay_filter_async_info;
 extern struct obs_source_info replay_source_info;
 
+#if defined(_WIN32)
 extern void RegisterDShowReplaySource();
+#endif
 
 bool obs_module_load(void)
 {
@@ -113,7 +115,9 @@ bool obs_module_load(void)
 	obs_register_source(&replay_filter_info);
 	obs_register_source(&replay_filter_audio_info);
 	obs_register_source(&replay_filter_async_info);
+#if defined(_WIN32)
 	RegisterDShowReplaySource();
+#endif
 	return true;
 }
 

--- a/replay.h
+++ b/replay.h
@@ -39,7 +39,6 @@ void free_audio_packet(struct obs_audio_data *audio);
 struct obs_audio_data *replay_filter_audio(void *data,struct obs_audio_data *audio);
 void free_video_data(struct replay_filter *filter);
 void free_audio_data(struct replay_filter *filter);
-obs_properties_t *replay_filter_properties(void *unused);
 void replay_trigger_threshold(void *data);
 void replay_filter_check(struct replay_filter* filter);
 


### PR DESCRIPTION
With these changes the plugin compiles and appears to work on OBS version 23.1.0 / Ubuntu version 18.04.2 LTS