### PR TITLE
Increase the value of maximum replays

### DIFF
--- a/replay-source.c
+++ b/replay-source.c
@@ -3292,7 +3292,7 @@ static obs_properties_t *replay_source_properties(void *data)
 				      1000);
 	obs_property_int_set_suffix(prop, "ms");
 	obs_properties_add_int(props, SETTING_REPLAYS,
-			       obs_module_text("MaxReplays"), 1, 10, 1);
+			       obs_module_text("MaxReplays"), 1, 20, 1);
 
 	prop = obs_properties_add_list(props, SETTING_VISIBILITY_ACTION,
 				       obs_module_text("VisibilityAction"),


### PR DESCRIPTION
I am using this plugin for an esports production and I usually record a clip for any nice play. Increasing the limit will allow me to clip more highlights and press a single button to make them all play easily

I looked around and I did not see if there was a reason why it was capped to 10. Let me know if this is not possible.