### PR TITLE
Fixes incorrect trim logic while paused

### DIFF
--- a/replay-source.c
+++ b/replay-source.c
@@ -1801,7 +1801,9 @@ static void replay_trim_front_hotkey(void *data, obs_hotkey_id id,
 	if (!pressed)
 		return;
 
-	const uint64_t timestamp = obs_get_video_frame_time();
+	const uint64_t timestamp = c->pause_timestamp == 0
+				     ? obs_get_video_frame_time()
+				     : c->pause_timestamp;
 	int64_t duration = timestamp - c->start_timestamp;
 	if (c->speed_percent != 100.0f) {
 		duration = (int64_t)(duration * c->speed_percent / 100.0);
@@ -1833,7 +1835,9 @@ static void replay_trim_end_hotkey(void *data, obs_hotkey_id id,
 
 	if (!pressed)
 		return;
-	const uint64_t timestamp = obs_get_video_frame_time();
+
+	const uint64_t timestamp = c->pause_timestamp == 0
+		? obs_get_video_frame_time() : c->pause_timestamp;
 	if (timestamp > c->start_timestamp) {
 		int64_t duration = timestamp - c->start_timestamp;
 		if (c->speed_percent != 100.0f) {


### PR DESCRIPTION
Previously, the trimming functions would only work properly while playing a replay. While paused, incorrect start and end times would be set. This change modifies the `replay_trim_front_hotkey` and `replay_trim_end_hotkey` callbacks to use the saved `pause_timestamp`  if set.

Tested by using the trim start and end functions while playing and while paused and while playing forward and backward.